### PR TITLE
Ensure that negative vertical accuracy is unknown

### DIFF
--- a/SeaLevel/SeaLevelFinder.swift
+++ b/SeaLevel/SeaLevelFinder.swift
@@ -11,16 +11,11 @@ class SealevelFinder {
     let padding = CLLocationDistance(15)
     
     func atSeaLevel(altitude: CLLocationDistance?, verticalAccuracy: CLLocationAccuracy) -> Bool? {
-        var result: Bool? = nil
-        if verticalAccuracy > -1 {
-            if altitude <= padding && altitude >= -padding {
-                result = true
-            }
-            else {
-                result = false
-            }
+        if verticalAccuracy < 0 {
+            return nil
         }
-        return result
+
+        return altitude <= padding && altitude >= -padding;
     }
 
 }

--- a/SeaLevelTests/SeaLevelTests.swift
+++ b/SeaLevelTests/SeaLevelTests.swift
@@ -23,6 +23,14 @@ class SeaLevelTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
+
+    func testNegativeVerticalAccuracyReturnsNil() {
+        var result = seaLevelFinder!.atSeaLevel(CLLocationDistance(0), verticalAccuracy: CLLocationAccuracy(-1))
+        XCTAssertNil(result)
+
+        result = seaLevelFinder!.atSeaLevel(CLLocationDistance(16), verticalAccuracy: CLLocationAccuracy(-0.5))
+        XCTAssertNil(result)
+    }
     
     func testAtSeaLevel() {
         // test location distance (altitude)


### PR DESCRIPTION
Since `CLLocationAccuracy` is a `Double`, it is possible for it to have a negative value between -1 and 0.  This just ensures that we don't get bit by that.

I also wrote it differently.  Feel free not to accept this if you don't like the way I did it.
